### PR TITLE
Dependencies: switch to using the fork of NumeralJS that Kibana uses

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "jquery": "^2.2.3",
     "lodash": "^4.13.1",
     "moment": "^2.13.0",
-    "numeral": "^1.5.3",
+    "@spalger/numeral": "^2.0.0",
     "react-resize-aware": "^1.0.11",
     "reactcss": "^1.0.7"
   },


### PR DESCRIPTION
The fork of NumeralJS that Kibana uses has this important feature: https://github.com/spalger/numeral-js/pull/1

Since `numeral` is a dependency here, if a Kibana plugin uses `thor-visualizations` and `numeral` in the UI, webpack will resort to picking `numeral` provided by this library, instead of getting it from Kibana's node_modules.

An alternative to having this change would be to have a webpackShim that can provide the intended NumeralJS. But since this lib is hosted under Elastic, this change seems appropriate.

Another alternative would be to have everyone switch to `numbro` which has the feature that I want: https://github.com/foretagsplatsen/numbro/pull/170
